### PR TITLE
Explore page limit set to 15 to load all the 3D models

### DIFF
--- a/src/routes/dashboard/explore/+page.server.ts
+++ b/src/routes/dashboard/explore/+page.server.ts
@@ -28,7 +28,7 @@ export async function load() {
 		.innerJoin(user, eq(devlog.userId, user.id))
         .where(eq(devlog.deleted, false))
         .orderBy(desc(devlog.createdAt))
-        .limit(100);
+        .limit(15);
 
 	return {
 		devlogs


### PR DESCRIPTION
With 100 devlogs, not all 3D models are loading correctly in Chrome.
The Chrome dev console warning is: **WARNING: Too many active WebGL contexts. Oldest context will be lost.**

As a result, the explore page looks like this:
<img width="1079" height="513" alt="Screenshot 2025-12-14 at 12 18 51" src="https://github.com/user-attachments/assets/6c49f9fc-eeb0-491e-a8ff-6679079645a2" />

By setting the limit to 15, this problem is fixed.